### PR TITLE
Fixed a lint warning due to code scoping.

### DIFF
--- a/gitfs/repository.py
+++ b/gitfs/repository.py
@@ -439,8 +439,16 @@ class Repository(object):
                                     first_branch, second_branch)
 
         for first_commit, second_commit in walker:
-            if (first_commit in second_commits or
-               second_commit in first_commits):
+            if first_commit in second_commits:
+                index = second_commits.index(first_commit)
+                second_commits = second_commits[:index]
+                common_parent = first_commit
+                break
+
+            if second_commit in first_commits:
+                index = first_commits.index(second_commit)
+                first_commits = first_commits[:index]
+                common_parent = second_commit
                 break
 
             if first_commit not in first_commits:
@@ -450,15 +458,5 @@ class Repository(object):
 
             if second_commit.hex == first_commit.hex:
                 break
-
-        if first_commit in second_commits:
-            index = second_commits.index(first_commit)
-            second_commits = second_commits[:index]
-            common_parent = first_commit
-
-        if second_commit in first_commits:
-            index = first_commits.index(second_commit)
-            first_commits = first_commits[:index]
-            common_parent = second_commit
 
         return DivergeCommits(common_parent, first_commits, second_commits)


### PR DESCRIPTION
Pylint reported first_commit and second_commit were being used when they
were defined in the for loop. Whilst this is valid Python 2/3, it is
better to avoid this. I have collapsed the code into the for loop as it
has the same logic in the end.

I mentioned this in #208.