### PR TITLE
Avoid searching branch commits lists twice

### DIFF
--- a/gitfs/repository.py
+++ b/gitfs/repository.py
@@ -460,13 +460,19 @@ class Repository(object):
             if second_commit.hex == first_commit.hex:
                 break
 
-        if first_commit in second_commits:
+        try:
             index = second_commits.index(first_commit)
+        except ValueError:
+            pass
+        else:
             second_commits = second_commits[:index]
             common_parent = first_commit
 
-        if second_commit in first_commits:
+        try:
             index = first_commits.index(second_commit)
+        except ValueError:
+            pass
+        else:
             first_commits = first_commits[:index]
             common_parent = second_commit
 


### PR DESCRIPTION
_Disclaimer: this is my first PR, so I apologize in advance in case it is not compliant with the project guidelines. :)_

Also, it does not exactly fix what is reported in https://github.com/PressLabs/gitfs/issues/208 but it introduces some small changes in the same method.

The current implementation can perform two searches in both `first_commits` and `second_commits` lists (first using `in` and second using `index`). This PR uses only `index` to search and use its return to decide whether to slice or not the lists.

Hope it helps