### PR TITLE
add current,history_path options

### DIFF
--- a/gitfs/mounter.py
+++ b/gitfs/mounter.py
@@ -23,7 +23,7 @@ from pygit2.remote import RemoteCallbacks
 
 from gitfs import __version__
 from gitfs.utils import Args
-from gitfs.routes import routes
+from gitfs.routes import prepare_routes
 from gitfs.router import Router
 from gitfs.worker import CommitQueue, SyncWorker, FetchWorker
 
@@ -58,6 +58,8 @@ def prepare_components(args):
         # setting router
         router = Router(remote_url=args.remote_url,
                         mount_path=args.mount_point,
+                        current_path=args.current_path,
+                        history_path=args.history_path,
                         repo_path=args.repo_path,
                         branch=args.branch,
                         user=args.user,
@@ -74,6 +76,7 @@ def prepare_components(args):
         raise error
 
     # register all the routes
+    routes = prepare_routes(args)
     router.register(routes)
 
     # setup workers

--- a/gitfs/router.py
+++ b/gitfs/router.py
@@ -33,7 +33,8 @@ from gitfs.log import log
 
 
 class Router(object):
-    def __init__(self, remote_url, repo_path, mount_path, credentials,
+    def __init__(self, remote_url, repo_path, mount_path,
+                 current_path, history_path, credentials,
                  branch=None, user="root", group="root", **kwargs):
         """
         Clone repo from a remote into repo_path/<repo_name> and checkout to
@@ -49,6 +50,8 @@ class Router(object):
         self.remote_url = remote_url
         self.repo_path = repo_path
         self.mount_path = mount_path
+        self.current_path = current_path
+        self.history_path = history_path
         self.branch = branch
 
         self.routes = []
@@ -180,6 +183,8 @@ class Router(object):
             kwargs['mount_path'] = self.mount_path
             kwargs['regex'] = route['regex']
             kwargs['relative_path'] = relative_path
+            kwargs['current_path'] = self.current_path
+            kwargs['history_path'] = self.history_path
             kwargs['uid'] = self.uid
             kwargs['gid'] = self.gid
             kwargs['branch'] = self.branch

--- a/gitfs/routes.py
+++ b/gitfs/routes.py
@@ -18,9 +18,17 @@ from gitfs.views import IndexView, CurrentView, HistoryView, CommitView
 
 # TODO: replace regex with the strict one for the Historyview
 # -> r'^/history/(?<date>(19|20)\d\d[-](0[1-9]|1[012])[-](0[1-9]|[12][0-9]|3[01]))/',
-routes = [
-        (r'^/history/(?P<date>\d{4}-\d{1,2}-\d{1,2})/(?P<time>\d{2}-\d{2}-\d{2})-(?P<commit_sha1>[0-9a-f]{10})', CommitView),
-        (r'^/history/(?P<date>\d{4}-\d{1,2}-\d{1,2})', HistoryView),
-        (r'^/history', HistoryView),
-        (r'^/current', CurrentView),
-        (r'^/', IndexView)]
+def prepare_routes(args):
+    routes = []
+
+    routes.append((r'^/%s/(?P<date>\d{4}-\d{1,2}-\d{1,2})/(?P<time>\d{2}-\d{2}-\d{2})-(?P<commit_sha1>[0-9a-f]{10})' % args.history_path, CommitView))
+    routes.append((r'^/%s/(?P<date>\d{4}-\d{1,2}-\d{1,2})' % args.history_path, HistoryView))
+    routes.append((r'^/%s' % args.history_path, HistoryView))
+
+    if ('/' == args.current_path):
+        routes.append((r'^/', CurrentView))
+    else:
+        routes.append((r'^/%s' % args.current_path, CurrentView))
+        routes.append((r'^/', IndexView))
+
+    return routes

--- a/gitfs/utils/args.py
+++ b/gitfs/utils/args.py
@@ -59,6 +59,8 @@ class Args(object):
             ("hard_ignore", ("", "string")),
             ("min_idle_times", (10, "float")),
             ("max_open_files", (-1, "int")),
+            ("history_path", ("history", "string")),
+            ("current_path", ("current", "string")),
         ])
         self.config = self.build_config(parser.parse_args())
 

--- a/gitfs/views/current.py
+++ b/gitfs/views/current.py
@@ -34,6 +34,8 @@ class CurrentView(PassthroughView):
         super(CurrentView, self).__init__(*args, **kwargs)
         self.dirty = {}
 
+        self.current_path = kwargs['current_path']
+
     @write_operation
     @not_in("ignore", check=["old", "new"])
     def rename(self, old, new):
@@ -64,8 +66,8 @@ class CurrentView(PassthroughView):
     @write_operation
     @not_in("ignore", check=["target"])
     def link(self, name, target):
-        if target.startswith('/current/'):
-            target = target.replace('/current/', '/')
+        if target.startswith('/%s/' % self.current_path):
+            target = target.replace('/%s/' % self.current_path, '/')
 
         result = super(CurrentView, self).link(target, name)
 

--- a/gitfs/views/index.py
+++ b/gitfs/views/index.py
@@ -23,6 +23,12 @@ from .read_only import ReadOnlyView
 
 class IndexView(ReadOnlyView):
 
+    def __init__(self, *args, **kwargs):
+        super(ReadOnlyView, self).__init__(*args, **kwargs)
+
+        self.current_path = kwargs['current_path']
+        self.history_path = kwargs['history_path']
+
     def getattr(self, path, fh=None):
         '''
         Returns a dictionary with keys identical to the stat C structure of
@@ -47,4 +53,4 @@ class IndexView(ReadOnlyView):
         return attrs
 
     def readdir(self, path, fh):
-        return ['.', '..', 'current', 'history']
+        return ['.', '..', self.current_path, self.history_path]

--- a/gitfs/views/passthrough.py
+++ b/gitfs/views/passthrough.py
@@ -33,6 +33,9 @@ class PassthroughView(View):
         self.repo = kwargs['repo']
         self.root = kwargs['repo_path']
 
+        self.is_current_path_root = ('/' == kwargs['current_path'])
+        self.history_path = kwargs['history_path']
+
     def access(self, path, mode):
         full_path = self.repo._full_path(path)
         if not os.access(full_path, mode):
@@ -63,6 +66,9 @@ class PassthroughView(View):
             for entry in os.listdir(full_path):
                 if entry not in hidden_items:
                     dirents.append(entry)
+
+        if self.is_current_path_root:
+            dirents.append(self.history_path)
 
         for directory in dirents:
             yield directory


### PR DESCRIPTION
This make it possible to have different `current` and `history` directories. The user can provide a new values via: `-o current_path="up-to-date",history_path="backup"`

By default the old `current` and `history` are kept.

Also Fixes #277 with the following options: `-o current_path="/",history_path=".history"`,

In case of `current_path="/"` the `history_path` also added to the directory list, and it can conflict with an existing directory, it may be good to note in the documentation.
