### PR TITLE
gitfs brew formula lives in homebrew-core

### DIFF
--- a/docs/documentation/usage.md
+++ b/docs/documentation/usage.md
@@ -13,7 +13,7 @@ sudo apt-get install gitfs
 Prerequisites
 - [Homebrew](http://brew.sh/)
 ```
-brew install homebrew/fuse/gitfs
+brew install gitfs
 ```
 
 ### Mounting


### PR DESCRIPTION
Homebrew moved all fuse formula to core 9 months ago. 

See https://github.com/Homebrew/homebrew-fuse/commit/4194c99d2af944e7abe29893a7f4b925bcc1cbb8