### PR TITLE
Reuse existing repo cache

### DIFF
--- a/gitfs/repository.py
+++ b/gitfs/repository.py
@@ -186,8 +186,16 @@ class Repository(object):
         clone. The default is to use the remote's default branch.
 
         """
-        existingRepoPath = discover_repository(path)
-        if existingRepoPath=="":
+        hasExistingRepo = False
+        try:    
+            existingRepoPath = discover_repository(path)
+            if existingRepoPath<>"":
+                hasExistingRepo = True
+        except Exception, e:
+            log.debug("[Exception] discover_repository repo not found: %s", str(e))
+            pass
+
+        if hasExistingRepo == False:
             log.debug("clone_repository %s", path)
             
             try:
@@ -207,7 +215,7 @@ class Repository(object):
                 log.error("[Exception] init_repository failed: %s", str(e))
                 sys.exit()
                 
-            log.info("existing repo opened")
+            log.info("existing repo '%s' opened", existingRepoPath)
 
         return cls(repo)
 

--- a/gitfs/repository.py
+++ b/gitfs/repository.py
@@ -14,14 +14,15 @@
 
 
 import os
+import sys
 from collections import namedtuple
 from shutil import rmtree
 from stat import S_IFDIR, S_IFREG, S_IFLNK
 
-from pygit2 import (clone_repository, Signature, GIT_SORT_TOPOLOGICAL,
+from pygit2 import (clone_repository, discover_repository, init_repository, Signature, GIT_SORT_TOPOLOGICAL,
                     GIT_FILEMODE_TREE, GIT_STATUS_CURRENT,
                     GIT_FILEMODE_LINK, GIT_FILEMODE_BLOB, GIT_BRANCH_REMOTE,
-                    GIT_BRANCH_LOCAL, GIT_FILEMODE_BLOB_EXECUTABLE)
+                    GIT_BRANCH_LOCAL, GIT_FILEMODE_BLOB_EXECUTABLE, GIT_REPOSITORY_INIT_NO_REINIT)
 from six import iteritems
 
 from gitfs.cache import CommitCache
@@ -185,10 +186,29 @@ class Repository(object):
         clone. The default is to use the remote's default branch.
 
         """
-
-        repo = clone_repository(remote_url, path, checkout_branch=branch,
+        existingRepoPath = discover_repository(path)
+        if existingRepoPath=="":
+            log.debug("clone_repository %s", path)
+            
+            try:
+                repo = clone_repository(remote_url, path, checkout_branch=branch,
                                 callbacks=credentials)
-        repo.checkout_head()
+            except Exception, e:
+                log.error("[Exception] clone_repository failed: %s", str(e))
+                sys.exit()
+                
+            repo.checkout_head()
+            log.info("repo cloned")
+        else:
+            log.debug("init_repository %s", existingRepoPath)
+            try:
+                repo = init_repository(existingRepoPath)
+            except Exception, e:
+                log.error("[Exception] init_repository failed: %s", str(e))
+                sys.exit()
+                
+            log.info("existing repo opened")
+
         return cls(repo)
 
     def _is_searched_entry(self, entry_name, searched_entry, path_components):

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,5 @@
-fusepy==2.0.2
-pygit2==0.24.1
-six==1.10.0
+fusepy>=2.0.4
+pygit2==0.26.0
+six>=1.10.0
 atomiclong
-raven==5.27.0
+raven>=6.1.0


### PR DESCRIPTION
I have a rather large (several gigs) git repo, it takes a while for cloning it upon mounting gitfs. I want to pass the repo_path argument pointing to existing local repo and skip cloning of the whole tree to speedup synchronization process.