### PR TITLE
self.repo.index.remove expect OSError when occured to rename quickly

### DIFF
--- a/gitfs/views/current.py
+++ b/gitfs/views/current.py
@@ -266,7 +266,10 @@ class CurrentView(PassthroughView):
                         path = path.replace("{}/".format(add), "{}/".format(remove))
                         self.repo.index.remove(path)
                 else:
-                    self.repo.index.remove(remove)
+                    try:
+                        self.repo.index.remove(remove)
+                    except OSError as e:
+                        log.debug("failed to remove from cache: [{}] {}".format(e, type(e)))
             else:
                 self.repo.index.remove(remove)
             non_empty = True


### PR DESCRIPTION
`self.repo.index.remove` remove an old file when renaming the file.

gitfs will execute `Rename` first if creating and renaming while waiting for a commit.
Then gitfs not execute `Create` and occurred `OSError`.

This change caught `OSError` when renaming and not committed the old file.

## Reproduce steps

1. Check a new file by gitfs, but not found
2. Create a new file (A) by hand or software
3. Rename a file (A to B) by hand or software
4. Check a new file by gitfs. gitfs found rename (A to B)
5. gitfs execute `self.repo.index.remove()`, it will be removed A. But self.repo not registered A. Then gitfs occurred `OSError`.

## Usecases

it that creating and renaming is very quickly in some storage software.
for example, a file of user-uploaded put to a sandbox to check vulnerability, file name, and more.

It renames the uploaded file after check.

