### PR TITLE
fix home envvar not defined during fstab mount

### DIFF
--- a/gitfs/utils/args.py
+++ b/gitfs/utils/args.py
@@ -185,7 +185,7 @@ class Args(object):
         return tempfile.mkdtemp(dir="/var/lib/gitfs")
 
     def get_ssh_key(self, args):
-        return os.environ["HOME"] + "/.ssh/id_rsa"
+        return os.getenv("HOME", "/root/") + "/.ssh/id_rsa"
 
     def get_sentry_dsn(self, args):
         return os.environ["SENTRY_DSN"] if "SENTRY_DSN" in os.environ else ""


### PR DESCRIPTION
Mounting git repo using `fstab` caused the following issue due to lack of env vars.

```
return os.environ["HOME"] + "/.ssh/id_rsa"                                                           
  File "/usr/lib/python3.7/os.py", line 678, in __getitem__                   
    raise KeyError(key) from None                                                                       
KeyError: 'HOME'   
```                 
