### PR TITLE
interpret only name args as boolean true

### DIFF
--- a/gitfs/utils/args.py
+++ b/gitfs/utils/args.py
@@ -72,6 +72,8 @@ class Args(object):
                 if "=" in arg:
                     item, value = arg.split("=")
                     setattr(args, item, value)
+                else:
+                    setattr(args, arg, "true")
 
         return self.check_args(self.set_defaults(args))
 


### PR DESCRIPTION
Currently, arguments like `allow_others` without value are ignored.
Maybe we should use them as boolean true flags.
