### PR TITLE
args: allow_root default False

### DIFF
--- a/gitfs/utils/args.py
+++ b/gitfs/utils/args.py
@@ -44,7 +44,7 @@ class Args(object):
                 ("foreground", (False, "bool")),
                 ("branch", ("master", "string")),
                 ("allow_other", (False, "bool")),
-                ("allow_root", (True, "bool")),
+                ("allow_root", (False, "bool")),
                 ("commiter_name", (self.get_commiter_user, "string")),
                 ("commiter_email", (self.get_commiter_email, "string")),
                 ("max_size", (10, "float")),

--- a/gitfs/utils/args.py
+++ b/gitfs/utils/args.py
@@ -76,12 +76,6 @@ class Args(object):
         return self.check_args(self.set_defaults(args))
 
     def check_args(self, args):
-        # check allow_other and allow_root
-        if args.allow_other:
-            args.allow_root = False
-        else:
-            args.allow_root = True
-
         # check log_level
         if args.debug:
             args.log_level = "debug"


### PR DESCRIPTION
make compatible with default config in `/etc/fuse.conf`

allow_root=True requires user_allow_other, which is default off

error was

```
fusermount: option allow_other only allowed if 'user_allow_other' is set in /etc/fuse.conf
```

edit: dammit, still getting the error, even with `-o allow_other=false,allow_root=false`
edit 2: fixed by removing the `args.allow_root = True` code