### PR TITLE
update: pygit2.remote.RemoteCallbacks -> pygit2.RemoteCallbacks

### DIFF
--- a/gitfs/mounter.py
+++ b/gitfs/mounter.py
@@ -18,8 +18,7 @@ import argparse
 import resource
 
 from fuse import FUSE
-from pygit2 import Keypair, UserPass
-from pygit2.remote import RemoteCallbacks
+from pygit2 import Keypair, UserPass, RemoteCallbacks
 
 from gitfs import __version__
 from gitfs.utils import Args


### PR DESCRIPTION
make it work with latest pygit2

error was

```
ImportError: cannot import name 'RemoteCallbacks' from 'pygit2.remote'
```

env

```
$ python --version 
Python 3.9.6

$ python -c 'import pygit2; print(pygit2.__version__)'
1.6.1
```

todo: patch `requirements.txt`

... or is this intentional?