### PR TITLE
Python 3.10: MutableMapping has moved to collections.abc

### DIFF
--- a/gitfs/cache/base.py
+++ b/gitfs/cache/base.py
@@ -12,10 +12,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-import collections
+try:
+    from collections.abc import MutableMapping
+except ImportError:
+    from collections import MutableMapping
 
 
-class Cache(collections.MutableMapping):
+class Cache(MutableMapping):
     """Mutable mapping to serve as a simple cache or cache base class.
 
     This class discards arbitrary items using :meth:`popitem` to make


### PR DESCRIPTION
https://docs.python.org/3/whatsnew/3.10.html#removed bullet eight...
* Remove deprecated aliases to Collections Abstract Base Classes from the collections module. (Contributed by Victor Stinner in bpo-37324.)

Related to Homebrew/homebrew-core#90923